### PR TITLE
Gas namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ yaeth --config-file=mainnet-config.json block --number=17081411 get
   - [x] eth_getStorageAt
   - [x] eth_getTransactionCount
 
-- [ ] Gas
-  - [ ] eth_estimateGas
-  - [ ] eth_feeHistory
-  - [ ] eth_gasPrice
-  - [ ] eth_maxPriorityFeePerGas
+- [x] Gas
+  - [x] eth_estimateGas
+  - [x] eth_feeHistory
+  - [x] eth_gasPrice
+  - [x] eth_maxPriorityFeePerGas
 
 - [ ] Utils
   - [ ] eth_accounts

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -43,17 +43,21 @@ impl ValueEnum for BlockTag {
     }
 }
 
-impl From<BlockTag> for BlockId {
+impl From<BlockTag> for BlockNumber {
     fn from(value: BlockTag) -> Self {
-        let tag = match value {
+        match value {
             BlockTag::Latest => BlockNumber::Latest,
             BlockTag::Finalized => BlockNumber::Finalized,
             BlockTag::Safe => BlockNumber::Safe,
             BlockTag::Earliest => BlockNumber::Earliest,
             BlockTag::Pending => BlockNumber::Pending,
-        };
+        }
+    }
+}
 
-        BlockId::Number(tag)
+impl From<BlockTag> for BlockId {
+    fn from(value: BlockTag) -> Self {
+        BlockId::Number(value.into())
     }
 }
 

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -1,5 +1,5 @@
 use clap::{builder::PossibleValue, Args, ValueEnum};
-use ethers::types::{BlockId, BlockNumber, H256};
+use ethers::types::{Address, BlockId, BlockNumber, Bytes, TransactionRequest, H256, U256, U64};
 use serde::Serializer;
 use thiserror::Error;
 
@@ -118,4 +118,103 @@ where
     S: Serializer,
 {
     s.serialize_none()
+}
+
+#[derive(Args, Debug)]
+pub struct TypedTransactionArgs {
+    #[arg(long)]
+    from: Option<Address>,
+
+    #[arg(long, conflicts_with = "ens")]
+    address: Option<Address>,
+
+    #[arg(long)]
+    ens: Option<String>,
+
+    #[arg(long)]
+    gas: Option<U256>,
+
+    #[arg(long)]
+    gas_price: Option<U256>,
+
+    /// Amount of Eth to send
+    #[arg(long)]
+    value: Option<U256>,
+
+    #[arg(long)]
+    data: Option<Bytes>,
+
+    #[arg(long)]
+    nonce: Option<U256>,
+
+    #[arg(long)]
+    chain_id: Option<U64>,
+}
+
+#[derive(Error, Debug)]
+pub enum TypedTransactionParserError {
+    #[error("Provided both ens and address")]
+    ConflictingTransactionReceiver,
+}
+
+impl TryFrom<TypedTransactionArgs> for TransactionRequest {
+    type Error = TypedTransactionParserError;
+
+    fn try_from(value: TypedTransactionArgs) -> Result<Self, Self::Error> {
+        let TypedTransactionArgs {
+            from,
+            address,
+            ens,
+            gas,
+            gas_price,
+            value,
+            data,
+            nonce,
+            chain_id,
+        } = value;
+
+        let mut tx = TransactionRequest::new();
+
+        if ens.is_some() && address.is_some() {
+            return Err(Self::Error::ConflictingTransactionReceiver);
+        }
+
+        if let Some(from) = from {
+            tx = tx.from(from)
+        }
+
+        if let Some(address) = address {
+            tx = tx.to(address)
+        }
+
+        if let Some(ens) = ens {
+            tx = tx.to(ens)
+        }
+
+        if let Some(gas) = gas {
+            tx = tx.gas(gas)
+        }
+
+        if let Some(gas_price) = gas_price {
+            tx = tx.gas_price(gas_price)
+        }
+
+        if let Some(value) = value {
+            tx = tx.value(value)
+        }
+
+        if let Some(data) = data {
+            tx = tx.data(data)
+        }
+
+        if let Some(nonce) = nonce {
+            tx = tx.nonce(nonce)
+        }
+
+        if let Some(chain_id) = chain_id {
+            tx = tx.chain_id(chain_id)
+        }
+
+        Ok(tx)
+    }
 }

--- a/src/cli/gas.rs
+++ b/src/cli/gas.rs
@@ -1,0 +1,142 @@
+use crate::{cmd, context::CommandExecutionContext};
+
+use super::common::{BlockIdParserError, BlockTag, GetBlockByIdArgs, NoArgs, TypedTransactionArgs};
+use clap::{command, Args, Parser, Subcommand};
+use ethers::types::{BlockNumber, FeeHistory, U256};
+use serde::Serialize;
+
+#[derive(Parser, Debug)]
+#[command()]
+pub struct GasCommand {
+    #[command(subcommand)]
+    command: GasSubCommand,
+}
+
+#[derive(Subcommand, Debug)]
+#[command()]
+pub enum GasSubCommand {
+    /// Estimates the gas used by the provided transaction
+    Estimate(EstimateGasArgs),
+
+    /// Gets the transaction base fee per gas and effective priority fee per gas for the specified block range
+    History(GetFeeHistoryArgs),
+
+    /// Gets the current estimated gas price
+    Price(NoArgs),
+
+    /// Gets the current estimated max priority gas fee
+    Fee(NoArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct EstimateGasArgs {
+    // Typed Tx args
+    #[clap(flatten)]
+    typed_tx: TypedTransactionArgs,
+
+    // Block id args
+    #[clap(flatten)]
+    get_block_by_id: GetBlockByIdArgs,
+}
+
+#[derive(Args, Debug)]
+pub struct GetFeeHistoryArgs {
+    /// The number of blocks to include in the requested range
+    #[clap()]
+    count: U256,
+
+    /// The highest block of the requested range
+    #[clap(flatten)]
+    last_block: LastBlockArgs,
+
+    /// A monotonically increasing list of percentiles values to use to sort transactions based on the gas consumed
+    #[clap()]
+    percentiles: Vec<f64>,
+}
+
+#[derive(Args, Debug)]
+pub struct LastBlockArgs {
+    /// Number of the target block
+    #[arg(
+        long,
+        value_name = "BLOCK_NUMBER",
+        required_unless_present("tag"),
+        conflicts_with("tag")
+    )]
+    number: Option<u64>,
+
+    /// Tag of the target block
+    #[arg(long, value_name = "BLOCK_TAG")]
+    tag: Option<BlockTag>,
+}
+
+impl TryFrom<LastBlockArgs> for BlockNumber {
+    type Error = BlockIdParserError;
+
+    fn try_from(value: LastBlockArgs) -> Result<Self, Self::Error> {
+        let LastBlockArgs { number, tag } = value;
+
+        if number.is_some() && tag.is_some() {
+            return Err(Self::Error::ConflictingBlockId);
+        }
+
+        if let Some(number) = number {
+            return Ok(number.into());
+        }
+
+        if let Some(tag) = tag {
+            return Ok(tag.into());
+        }
+
+        Err(Self::Error::MissingBlockId)
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum GasNamespaceResult {
+    Estimate(U256),
+    Price(U256),
+    Fee(U256),
+    GetFeeHistory(FeeHistory),
+}
+
+pub fn parse(
+    context: &CommandExecutionContext,
+    sub_command: GasCommand,
+) -> Result<GasNamespaceResult, anyhow::Error> {
+    let node_provider = context.node_provider();
+
+    let res: GasNamespaceResult = match sub_command.command {
+        GasSubCommand::Estimate(EstimateGasArgs {
+            get_block_by_id,
+            typed_tx,
+        }) => context
+            .execute(cmd::gas::estimate_gas(
+                node_provider,
+                typed_tx.try_into()?,
+                get_block_by_id.try_into().ok(),
+            ))
+            .map(GasNamespaceResult::Estimate),
+        GasSubCommand::History(GetFeeHistoryArgs {
+            count,
+            last_block,
+            percentiles,
+        }) => context
+            .execute(cmd::gas::get_fee_history(
+                node_provider,
+                count,
+                last_block.try_into()?,
+                percentiles,
+            ))
+            .map(GasNamespaceResult::GetFeeHistory),
+        GasSubCommand::Price(_) => context
+            .execute(cmd::gas::gas_price(node_provider))
+            .map(GasNamespaceResult::Price),
+        GasSubCommand::Fee(_) => context
+            .execute(cmd::gas::get_max_priority_fee(node_provider))
+            .map(GasNamespaceResult::Fee),
+    }?;
+
+    Ok(res)
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,5 @@
 pub mod account;
 pub mod block;
 mod common;
+pub mod gas;
 pub mod transaction;

--- a/src/cmd/gas.rs
+++ b/src/cmd/gas.rs
@@ -1,0 +1,147 @@
+use ethers::{
+    providers::Middleware,
+    types::{BlockId, BlockNumber, FeeHistory, TransactionRequest, U256},
+};
+
+use crate::context::NodeProvider;
+
+// eth_estimateGas
+pub async fn estimate_gas(
+    node_provider: &NodeProvider,
+    tx: TransactionRequest,
+    block_id: Option<BlockId>,
+) -> anyhow::Result<U256> {
+    let estimated_gas = node_provider.estimate_gas(&tx.into(), block_id).await?;
+
+    Ok(estimated_gas)
+}
+
+// eth_feeHistory
+pub async fn get_fee_history(
+    node_provider: &NodeProvider,
+    block_count: U256,
+    last_block: BlockNumber,
+    reward_percentiles: Vec<f64>,
+) -> anyhow::Result<FeeHistory> {
+    let fee_history = node_provider
+        .fee_history(block_count, last_block, &reward_percentiles)
+        .await?;
+
+    Ok(fee_history)
+}
+
+// eth_gasPrice
+pub async fn gas_price(node_provider: &NodeProvider) -> anyhow::Result<U256> {
+    let current_gas_price = node_provider.get_gas_price().await?;
+
+    Ok(current_gas_price)
+}
+
+// eth_maxPriorityFeePerGas
+pub async fn get_max_priority_fee(node_provider: &NodeProvider) -> anyhow::Result<U256> {
+    let current_max_priority_fee = node_provider.get_eth_max_priority_fee_per_gas().await?;
+
+    Ok(current_max_priority_fee)
+}
+
+#[cfg(test)]
+mod tests {
+
+    mod estimate_gas {
+        use ethers::types::TransactionRequest;
+
+        use crate::cmd::{gas::estimate_gas, helpers::test::setup_test_with_no_context};
+
+        #[tokio::test]
+        async fn should_get_the_gas_usage_estimation() -> anyhow::Result<()> {
+            // Arrange
+            let (node_provider, anvil) = setup_test_with_no_context().await?;
+
+            let sender = *anvil.addresses().get(0).unwrap();
+            let receiver = *anvil.addresses().get(1).unwrap();
+
+            let typed_tx = TransactionRequest::new().from(sender).to(receiver);
+
+            let expected_gas = 21_000;
+
+            // Act
+            let res = estimate_gas(&node_provider, typed_tx, None).await;
+
+            // Assert
+            assert!(res.is_ok());
+            let res = res.unwrap();
+
+            assert_eq!(res, expected_gas.into());
+
+            Ok(())
+        }
+    }
+
+    mod get_fee_history {
+        use ethers::types::BlockNumber;
+
+        use crate::cmd::{gas::get_fee_history, helpers::test::setup_test_with_no_context};
+
+        #[tokio::test]
+        async fn should_get_the_gas_usage_estimation() -> anyhow::Result<()> {
+            // Arrange
+            let (node_provider, _anvil) = setup_test_with_no_context().await?;
+
+            // Act
+            let res = get_fee_history(
+                &node_provider,
+                10.into(),
+                BlockNumber::Finalized,
+                [90.0, 97.7].into(),
+            )
+            .await;
+
+            // Assert
+            assert!(res.is_ok());
+
+            Ok(())
+        }
+    }
+
+    mod gas_price {
+        use crate::cmd::{gas::gas_price, helpers::test::setup_test_with_no_context};
+
+        #[tokio::test]
+        async fn should_get_the_gas_price() -> anyhow::Result<()> {
+            // Arrange
+            let (node_provider, _anvil) = setup_test_with_no_context().await?;
+
+            // Act
+            let res = gas_price(&node_provider).await;
+
+            // Assert
+            assert!(res.is_ok());
+            let res = res.unwrap();
+
+            assert!(res > 0.into());
+
+            Ok(())
+        }
+    }
+
+    mod get_max_priority_fee {
+        use crate::cmd::{gas::get_max_priority_fee, helpers::test::setup_test_with_no_context};
+
+        #[tokio::test]
+        async fn should_get_max_priority_fee() -> anyhow::Result<()> {
+            // Arrange
+            let (node_provider, _anvil) = setup_test_with_no_context().await?;
+
+            // Act
+            let res = get_max_priority_fee(&node_provider).await;
+
+            // Assert
+            assert!(res.is_ok());
+            let res = res.unwrap();
+
+            assert!(res > 0.into());
+
+            Ok(())
+        }
+    }
+}

--- a/src/cmd/gas.rs
+++ b/src/cmd/gas.rs
@@ -45,7 +45,7 @@ pub async fn gas_price(node_provider: &NodeProvider) -> anyhow::Result<U256> {
 
 // eth_maxPriorityFeePerGas
 pub async fn get_max_priority_fee(node_provider: &NodeProvider) -> anyhow::Result<U256> {
-    let current_max_priority_fee = node_provider.get_eth_max_priority_fee_per_gas().await?;
+    let current_max_priority_fee = node_provider.get_max_priority_fee_per_gas().await?;
 
     Ok(current_max_priority_fee)
 }

--- a/src/cmd/gas.rs
+++ b/src/cmd/gas.rs
@@ -162,7 +162,7 @@ mod tests {
         use crate::cmd::{gas::get_max_priority_fee, helpers::test::setup_test_with_no_context};
 
         #[tokio::test]
-        async fn should_get_max_priority_fee() -> anyhow::Result<()> {
+        async fn should_get_the_max_priority_fee() -> anyhow::Result<()> {
             // Arrange
             let (node_provider, _anvil) = setup_test_with_no_context().await?;
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 pub mod account;
 pub mod block;
+pub mod gas;
 mod helpers;
 pub mod transaction;

--- a/src/context.rs
+++ b/src/context.rs
@@ -84,7 +84,7 @@ impl NodeProvider {
     }
 
     /// Returns the current max priority fee per gas in wei.
-    pub async fn get_eth_max_priority_fee_per_gas(&self) -> anyhow::Result<U256> {
+    pub async fn get_max_priority_fee_per_gas(&self) -> anyhow::Result<U256> {
         let res = self.inner().request("eth_maxPriorityFeePerGas", ()).await?;
 
         Ok(res)

--- a/src/context.rs
+++ b/src/context.rs
@@ -6,7 +6,7 @@ use ethers::{
     },
     providers::{Http, MiddlewareError, PendingTransaction, Provider, ProviderError},
     signers::{LocalWallet, Wallet},
-    types::{transaction::eip2718::TypedTransaction, BlockId},
+    types::{transaction::eip2718::TypedTransaction, BlockId, U256},
 };
 use std::future::Future;
 use thiserror::Error;
@@ -81,6 +81,13 @@ impl NodeProvider {
         };
 
         Ok(provider)
+    }
+
+    /// Returns the current max priority fee per gas in wei.
+    pub async fn get_eth_max_priority_fee_per_gas(&self) -> anyhow::Result<U256> {
+        let res = self.inner().request("eth_maxPriorityFeePerGas", ()).await?;
+
+        Ok(res)
     }
 }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -7,6 +7,7 @@ use crate::{
     cli::{
         account::{self, AccountCommand, AccountNamespaceResult},
         block::{self, BlockCommand, BlockNamespaceResult},
+        gas::{self, GasCommand, GasNamespaceResult},
         transaction::{self, TransactionCommand, TransactionNamespaceResult},
     },
     config::{get_config, ConfigOverrides},
@@ -65,8 +66,7 @@ enum Command {
     Event(NoSubCommand),
 
     /// Execute gas related operations
-    #[command(subcommand)]
-    Gas(NoSubCommand),
+    Gas(GasCommand),
 
     /// Collection of utils
     #[command(subcommand)]
@@ -83,6 +83,7 @@ pub enum CliResult {
     BlockNamespace(BlockNamespaceResult),
     AccountNamespace(AccountNamespaceResult),
     TransactionNamespace(TransactionNamespaceResult),
+    GasNamespace(GasNamespaceResult),
 }
 
 #[derive(Debug, Clone)]
@@ -145,7 +146,7 @@ pub fn run() -> Result<(), anyhow::Error> {
             transaction::parse(&execution_context, cmd).map(CliResult::TransactionNamespace)
         }
         Command::Event(_) => todo!(),
-        Command::Gas(_) => todo!(),
+        Command::Gas(cmd) => gas::parse(&execution_context, cmd).map(CliResult::GasNamespace),
         Command::Utils(_) => todo!(),
     }?;
 


### PR DESCRIPTION
### Changelog

- Implements `gas` related methods from the Ethereum execution APUI spec
- Tests the `gas` methods
- Moves the `get_raw_block` to the `cmd/helpers` mod
- Implements the `get_block_number_by_block_id` helper
- Implements the `get_max_priority_fee_per_gas` on the `NodeProvider`
- Implements the `From<BlockTag>` trait for `BlockNumber`
- Updates the `From<BlockTag>` trait implementation for `BlockId`
- Moves the `TypedTransactionArgs` struct to the `cli/common` mod 