### PR TITLE
Refactor transaction namespace

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -61,18 +61,20 @@ impl From<BlockTag> for BlockId {
     }
 }
 
+pub const GET_BLOCK_BY_ID_ARG_GROUP_NAME: &str = "block_by_id";
+
 #[derive(Args, Debug)]
 pub struct GetBlockByIdArgs {
     /// Hash of the target block
-    #[arg(long, value_name = "BLOCK_HASH",conflicts_with_all(["number","tag"]))]
+    #[arg(group=GET_BLOCK_BY_ID_ARG_GROUP_NAME, long, value_name = "BLOCK_HASH",conflicts_with_all(["number","tag"]))]
     hash: Option<H256>,
 
     /// Number of the target block
-    #[arg(long, value_name = "BLOCK_NUMBER", conflicts_with_all(["hash","tag"]))]
+    #[arg(group=GET_BLOCK_BY_ID_ARG_GROUP_NAME,long, value_name = "BLOCK_NUMBER", conflicts_with_all(["hash","tag"]))]
     number: Option<u64>,
 
     /// Tag of the target block
-    #[arg(long, value_name = "BLOCK_TAG", conflicts_with_all(["hash","number"]))]
+    #[arg(group=GET_BLOCK_BY_ID_ARG_GROUP_NAME,long, value_name = "BLOCK_TAG", conflicts_with_all(["hash","number"]))]
     tag: Option<BlockTag>,
 }
 

--- a/src/cli/transaction.rs
+++ b/src/cli/transaction.rs
@@ -11,7 +11,7 @@ use crate::{
 
 use super::common::{
     parse_not_found, BlockIdParserError, GetBlockByIdArgs, NoArgs, TypedTransactionArgs,
-    TypedTransactionParserError,
+    TypedTransactionParserError, GET_BLOCK_BY_ID_ARG_GROUP_NAME,
 };
 use clap::{arg, command, Args, Parser, Subcommand};
 use ethers::types::{Bytes, Transaction, TransactionReceipt, H256};
@@ -50,9 +50,8 @@ pub struct GetTransactionArgs {
     #[clap(flatten)]
     get_block_by_id: GetBlockByIdArgs,
 
-    // TODO: reimplement the required constraint if any of the block ids field is set
     /// Index of the transaction in the block
-    #[arg(long, value_name = "TRANSACTION_INDEX")]
+    #[arg(long, value_name = "TRANSACTION_INDEX", requires = GET_BLOCK_BY_ID_ARG_GROUP_NAME)]
     index: Option<u64>,
 }
 

--- a/src/cli/transaction.rs
+++ b/src/cli/transaction.rs
@@ -195,10 +195,12 @@ pub fn parse(
 ) -> Result<TransactionNamespaceResult, anyhow::Error> {
     let TransactionCommand { hash, command } = sub_command;
 
+    let node_provider = context.node_provider();
+
     let res: TransactionNamespaceResult = match command {
         TransactionSubCommand::Get(get_transaction_args) => context
             .execute(cmd::transaction::get_transaction(
-                context,
+                node_provider,
                 hash.map(GetTransaction::TransactionHash)
                     .map_or_else(|| get_transaction_args.try_into(), Ok)?,
             ))?
@@ -208,7 +210,7 @@ pub fn parse(
             ),
         TransactionSubCommand::Receipt(_) => context
             .execute(cmd::transaction::get_transaction_receipt(
-                context,
+                node_provider,
                 hash.ok_or(anyhow::anyhow!(
                     "Missing required argument transaction hash"
                 ))?,
@@ -219,13 +221,13 @@ pub fn parse(
             ),
         TransactionSubCommand::Send(send_transaction_args) => context
             .execute(cmd::transaction::send_transaction(
-                context,
+                node_provider,
                 send_transaction_args.try_into()?,
             ))
             .map(TransactionNamespaceResult::SentTransaction)?,
         TransactionSubCommand::Call(simulate_transaction_args) => context
             .execute(cmd::transaction::call(
-                context,
+                node_provider,
                 simulate_transaction_args.try_into()?,
             ))
             .map(TransactionNamespaceResult::Call)?,

--- a/src/cmd/account.rs
+++ b/src/cmd/account.rs
@@ -73,12 +73,12 @@ mod tests {
     mod get_balance {
         use ethers::utils::parse_ether;
 
-        use crate::cmd::{account::get_balance, helpers::test::setup_test_with_no_context};
+        use crate::cmd::{account::get_balance, helpers::test::setup_test};
 
         #[tokio::test]
         async fn should_get_the_account_balance() -> anyhow::Result<()> {
             // Arrange
-            let (node_provider, anvil) = setup_test_with_no_context().await?;
+            let (node_provider, anvil) = setup_test().await?;
 
             let account = *anvil.addresses().get(0).unwrap();
 
@@ -99,12 +99,12 @@ mod tests {
     }
 
     mod get_code {
-        use crate::cmd::{account::get_code, helpers::test::setup_test_with_no_context};
+        use crate::cmd::{account::get_code, helpers::test::setup_test};
 
         #[tokio::test]
         async fn should_get_the_account_code() -> anyhow::Result<()> {
             // Arrange
-            let (node_provider, anvil) = setup_test_with_no_context().await?;
+            let (node_provider, anvil) = setup_test().await?;
 
             let account = *anvil.addresses().get(0).unwrap();
 
@@ -124,14 +124,12 @@ mod tests {
     mod get_transaction_count {
         use ethers::types::U256;
 
-        use crate::cmd::{
-            account::get_transaction_count, helpers::test::setup_test_with_no_context,
-        };
+        use crate::cmd::{account::get_transaction_count, helpers::test::setup_test};
 
         #[tokio::test]
         async fn should_get_the_account_transaction_count() -> anyhow::Result<()> {
             // Arrange
-            let (node_provider, anvil) = setup_test_with_no_context().await?;
+            let (node_provider, anvil) = setup_test().await?;
 
             let account = *anvil.addresses().get(0).unwrap();
 
@@ -153,12 +151,12 @@ mod tests {
     mod get_storage_at {
         use ethers::types::H256;
 
-        use crate::cmd::{account::get_storage_at, helpers::test::setup_test_with_no_context};
+        use crate::cmd::{account::get_storage_at, helpers::test::setup_test};
 
         #[tokio::test]
         async fn should_get_the_storage_data_in_the_selected_slot() -> anyhow::Result<()> {
             // Arrange
-            let (node_provider, anvil) = setup_test_with_no_context().await?;
+            let (node_provider, anvil) = setup_test().await?;
 
             let account = *anvil.addresses().get(0).unwrap();
 

--- a/src/cmd/block.rs
+++ b/src/cmd/block.rs
@@ -98,13 +98,13 @@ mod tests {
 
         use crate::cmd::{
             block::{get_block, BlockKind},
-            helpers::test::setup_test_with_no_context,
+            helpers::test::setup_test,
         };
 
         #[tokio::test]
         async fn should_not_find_a_non_existing_block() -> anyhow::Result<()> {
             // Arrange
-            let (node_provider, _anvil) = setup_test_with_no_context().await?;
+            let (node_provider, _anvil) = setup_test().await?;
 
             // Act
             let res = get_block(
@@ -126,7 +126,7 @@ mod tests {
         #[tokio::test]
         async fn should_get_the_block() -> anyhow::Result<()> {
             // Arrange
-            let (node_provider, _anvil) = setup_test_with_no_context().await?;
+            let (node_provider, _anvil) = setup_test().await?;
 
             // Act
             let res = get_block(&node_provider, BlockId::Number(BlockNumber::Latest), false).await;
@@ -143,7 +143,7 @@ mod tests {
         #[tokio::test]
         async fn should_get_the_block_without_transactions() -> anyhow::Result<()> {
             // Arrange
-            let (node_provider, _anvil) = setup_test_with_no_context().await?;
+            let (node_provider, _anvil) = setup_test().await?;
 
             // Act
             let res = get_block(&node_provider, BlockId::Number(BlockNumber::Latest), false).await;
@@ -162,7 +162,7 @@ mod tests {
         #[tokio::test]
         async fn should_get_the_block_with_transactions() -> anyhow::Result<()> {
             // Arrange
-            let (node_provider, _anvil) = setup_test_with_no_context().await?;
+            let (node_provider, _anvil) = setup_test().await?;
 
             // Act
             let res = get_block(&node_provider, BlockId::Number(BlockNumber::Latest), true).await;
@@ -185,12 +185,12 @@ mod tests {
     mod get_block_number {
         use ethers::types::U64;
 
-        use crate::cmd::{block::get_block_number, helpers::test::setup_test_with_no_context};
+        use crate::cmd::{block::get_block_number, helpers::test::setup_test};
 
         #[tokio::test]
         async fn should_get_the_block_number() -> anyhow::Result<()> {
             // Arrange
-            let (node_provider, _anvil) = setup_test_with_no_context().await?;
+            let (node_provider, _anvil) = setup_test().await?;
 
             // Act
             let res = get_block_number(&node_provider).await;
@@ -208,12 +208,12 @@ mod tests {
     mod get_transaction_count {
         use ethers::types::{BlockId, BlockNumber, U256};
 
-        use crate::cmd::{block::get_transaction_count, helpers::test::setup_test_with_no_context};
+        use crate::cmd::{block::get_transaction_count, helpers::test::setup_test};
 
         #[tokio::test]
         async fn should_get_the_block_tx_count_for_an_existing_block() -> anyhow::Result<()> {
             // Arrange
-            let (node_provider, _anvil) = setup_test_with_no_context().await?;
+            let (node_provider, _anvil) = setup_test().await?;
 
             // Act
             let res =
@@ -235,7 +235,7 @@ mod tests {
         async fn should_not_find_the_block_tx_count_for_a_non_existing_block() -> anyhow::Result<()>
         {
             // Arrange
-            let (node_provider, _anvil) = setup_test_with_no_context().await?;
+            let (node_provider, _anvil) = setup_test().await?;
 
             // Act
             let res = get_transaction_count(
@@ -257,12 +257,12 @@ mod tests {
     mod get_uncle_block_count {
         use ethers::types::{BlockId, BlockNumber, U256};
 
-        use crate::cmd::{block::get_uncle_block_count, helpers::test::setup_test_with_no_context};
+        use crate::cmd::{block::get_uncle_block_count, helpers::test::setup_test};
 
         #[tokio::test]
         async fn should_get_uncle_block_count() -> anyhow::Result<()> {
             // Arrange
-            let (node_provider, _anvil) = setup_test_with_no_context().await?;
+            let (node_provider, _anvil) = setup_test().await?;
 
             // Act
             let res =

--- a/src/cmd/gas.rs
+++ b/src/cmd/gas.rs
@@ -56,12 +56,12 @@ mod tests {
     mod estimate_gas {
         use ethers::types::TransactionRequest;
 
-        use crate::cmd::{gas::estimate_gas, helpers::test::setup_test_with_no_context};
+        use crate::cmd::{gas::estimate_gas, helpers::test::setup_test};
 
         #[tokio::test]
         async fn should_get_the_gas_usage_estimation() -> anyhow::Result<()> {
             // Arrange
-            let (node_provider, anvil) = setup_test_with_no_context().await?;
+            let (node_provider, anvil) = setup_test().await?;
 
             let sender = *anvil.addresses().get(0).unwrap();
             let receiver = *anvil.addresses().get(1).unwrap();
@@ -86,12 +86,12 @@ mod tests {
     mod get_fee_history {
         use ethers::types::{BlockNumber, H256};
 
-        use crate::cmd::{gas::get_fee_history, helpers::test::setup_test_with_no_context};
+        use crate::cmd::{gas::get_fee_history, helpers::test::setup_test};
 
         #[tokio::test]
         async fn should_get_the_fee_history() -> anyhow::Result<()> {
             // Arrange
-            let (node_provider, _anvil) = setup_test_with_no_context().await?;
+            let (node_provider, _anvil) = setup_test().await?;
 
             // Act
             let res = get_fee_history(
@@ -114,7 +114,7 @@ mod tests {
         #[tokio::test]
         async fn should_not_find_fee_history_for_non_existing_block() -> anyhow::Result<()> {
             // Arrange
-            let (node_provider, _anvil) = setup_test_with_no_context().await?;
+            let (node_provider, _anvil) = setup_test().await?;
 
             // Act
             let res = get_fee_history(
@@ -138,12 +138,12 @@ mod tests {
     }
 
     mod gas_price {
-        use crate::cmd::{gas::gas_price, helpers::test::setup_test_with_no_context};
+        use crate::cmd::{gas::gas_price, helpers::test::setup_test};
 
         #[tokio::test]
         async fn should_get_the_gas_price() -> anyhow::Result<()> {
             // Arrange
-            let (node_provider, _anvil) = setup_test_with_no_context().await?;
+            let (node_provider, _anvil) = setup_test().await?;
 
             // Act
             let res = gas_price(&node_provider).await;
@@ -159,12 +159,12 @@ mod tests {
     }
 
     mod get_max_priority_fee {
-        use crate::cmd::{gas::get_max_priority_fee, helpers::test::setup_test_with_no_context};
+        use crate::cmd::{gas::get_max_priority_fee, helpers::test::setup_test};
 
         #[tokio::test]
         async fn should_get_the_max_priority_fee() -> anyhow::Result<()> {
             // Arrange
-            let (node_provider, _anvil) = setup_test_with_no_context().await?;
+            let (node_provider, _anvil) = setup_test().await?;
 
             // Act
             let res = get_max_priority_fee(&node_provider).await;

--- a/src/cmd/helpers.rs
+++ b/src/cmd/helpers.rs
@@ -47,22 +47,10 @@ pub mod test {
 
     use crate::{
         config::{get_config, ConfigOverrides},
-        context::{CommandExecutionContext, NodeProvider},
+        context::NodeProvider,
     };
 
-    pub fn setup_test() -> anyhow::Result<(CommandExecutionContext, AnvilInstance)> {
-        let anvil = Anvil::new().spawn();
-
-        let overrides = ConfigOverrides::new(None, Some(anvil.endpoint()), None);
-
-        let config = get_config(overrides)?;
-
-        let execution_context = CommandExecutionContext::new(config)?;
-
-        Ok((execution_context, anvil))
-    }
-
-    pub async fn setup_test_with_no_context() -> anyhow::Result<(NodeProvider, AnvilInstance)> {
+    pub async fn setup_test() -> anyhow::Result<(NodeProvider, AnvilInstance)> {
         let anvil = Anvil::new().spawn();
 
         let overrides = ConfigOverrides::new(None, Some(anvil.endpoint()), None);


### PR DESCRIPTION
### Changelog

- Normalizes the transaction namespace to use the `NodeProvider` instead of the `CommandExecutionContext`
- Updates tests for the transaction namespace
- Reimplements the required constraint when using the `index` field when getting a transaction by block
- Removes the `setup_test` utils and renamed the `setup_test_no_context` to `setup_test`