### PR TITLE
Utils namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,16 +122,16 @@ yaeth --config-file=mainnet-config.json block --number=17081411 get
   - [x] eth_maxPriorityFeePerGas
 
 - [ ] Utils
-  - [ ] eth_accounts
-  - [ ] eth_chainId
+  - [x] eth_accounts
+  - [x] eth_chainId
   - [ ] eth_coinbase
-  - [ ] eth_getProof
+  - [x] eth_getProof
   - [ ] eth_getRootHash
   - [ ] eth_hashrate
   - [ ] eth_mining
-  - [ ] eth_protocolVersion
-  - [ ] eth_sign
-  - [ ] eth_syncing
+  - [x] eth_protocolVersion
+  - [x] eth_sign
+  - [x] eth_syncing
 
 - [ ] Event / Logs
   - [ ] eth_getFilterChanges

--- a/README.md
+++ b/README.md
@@ -121,14 +121,10 @@ yaeth --config-file=mainnet-config.json block --number=17081411 get
   - [x] eth_gasPrice
   - [x] eth_maxPriorityFeePerGas
 
-- [ ] Utils
+- [x] Utils
   - [x] eth_accounts
   - [x] eth_chainId
-  - [ ] eth_coinbase
   - [x] eth_getProof
-  - [ ] eth_getRootHash
-  - [ ] eth_hashrate
-  - [ ] eth_mining
   - [x] eth_protocolVersion
   - [x] eth_sign
   - [x] eth_syncing

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -1,10 +1,9 @@
 use crate::{cmd, context::CommandExecutionContext};
 
-use super::common::{GetBlockByIdArgs, NoArgs};
+use super::common::{GetAccountArgs, GetBlockByIdArgs, NoArgs};
 use clap::{command, Args, Parser, Subcommand};
-use ethers::types::{Bytes, NameOrAddress, H160, H256, U256};
+use ethers::types::{Bytes, H256, U256};
 use serde::Serialize;
-use thiserror::Error;
 
 #[derive(Parser, Debug)]
 #[command()]
@@ -17,45 +16,6 @@ pub struct AccountCommand {
 
     #[command(subcommand)]
     command: AccountSubCommand,
-}
-
-#[derive(Args, Debug)]
-pub struct GetAccountArgs {
-    #[arg(long, conflicts_with = "ens", required_unless_present = "ens")]
-    address: Option<H160>,
-
-    #[arg(long)]
-    ens: Option<String>,
-}
-
-#[derive(Error, Debug)]
-pub enum GetAccountParserError {
-    #[error("Provided multiple account identifiers. Either an ens or address must be provided.")]
-    ConflictingAccountId,
-
-    #[error("Missing account identifier. An ens or address must be provided.")]
-    MissingAccountId,
-}
-
-impl TryFrom<GetAccountArgs> for NameOrAddress {
-    type Error = GetAccountParserError;
-
-    fn try_from(GetAccountArgs { address, ens }: GetAccountArgs) -> Result<Self, Self::Error> {
-        // Sanity check
-        if address.is_some() && ens.is_some() {
-            return Err(Self::Error::ConflictingAccountId);
-        }
-
-        if let Some(address) = address {
-            return Ok(NameOrAddress::Address(address));
-        };
-
-        if let Some(ens) = ens {
-            return Ok(NameOrAddress::Name(ens));
-        };
-
-        Err(Self::Error::MissingAccountId)
-    }
 }
 
 #[derive(Args, Debug)]

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -130,15 +130,15 @@ where
 
 #[derive(Args, Debug)]
 pub struct TypedTransactionArgs {
-    /// Address from which the transaction will be sent
+    /// Address of the account from which the transaction will be sent
     #[arg(long)]
     from: Option<Address>,
 
-    /// Address to send the transaction to
+    /// Address of the account to send the transaction to
     #[arg(long, conflicts_with = "ens_to")]
     to: Option<Address>,
 
-    /// Ens name to send the transaction to
+    /// Ens name of the account to send the transaction to
     #[arg(long)]
     ens_to: Option<String>,
 
@@ -187,7 +187,7 @@ impl TryFrom<TypedTransactionArgs> for TransactionRequest {
     fn try_from(value: TypedTransactionArgs) -> Result<Self, Self::Error> {
         let TypedTransactionArgs {
             from,
-            to: address,
+            to,
             ens_to,
             gas,
             gas_price,
@@ -199,7 +199,7 @@ impl TryFrom<TypedTransactionArgs> for TransactionRequest {
 
         let mut tx = TransactionRequest::new();
 
-        if ens_to.is_some() && address.is_some() {
+        if ens_to.is_some() && to.is_some() {
             return Err(Self::Error::ConflictingTransactionReceiver);
         }
 
@@ -207,8 +207,8 @@ impl TryFrom<TypedTransactionArgs> for TransactionRequest {
             tx = tx.from(from)
         }
 
-        if let Some(address) = address {
-            tx = tx.to(address)
+        if let Some(to) = to {
+            tx = tx.to(to)
         }
 
         if let Some(ens) = ens_to {

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -130,14 +130,17 @@ where
 
 #[derive(Args, Debug)]
 pub struct TypedTransactionArgs {
+    /// Address from which the transaction will be sent
     #[arg(long)]
     from: Option<Address>,
 
-    #[arg(long, conflicts_with = "ens")]
-    address: Option<Address>,
+    /// Address to send the transaction to
+    #[arg(long, conflicts_with = "ens_to")]
+    to: Option<Address>,
 
+    /// Ens name to send the transaction to
     #[arg(long)]
-    ens: Option<String>,
+    ens_to: Option<String>,
 
     #[arg(long)]
     gas: Option<U256>,
@@ -149,6 +152,7 @@ pub struct TypedTransactionArgs {
     #[arg(long)]
     value: Option<U256>,
 
+    /// Calldata to send to the target account
     #[arg(long)]
     data: Option<Bytes>,
 
@@ -158,6 +162,18 @@ pub struct TypedTransactionArgs {
     #[arg(long)]
     chain_id: Option<U64>,
 }
+
+pub const TX_ARGS_FIELD_NAMES: [&str; 9] = [
+    "from",
+    "to",
+    "ens_to",
+    "gas",
+    "gas_price",
+    "value",
+    "data",
+    "nonce",
+    "chain_id",
+];
 
 #[derive(Error, Debug)]
 pub enum TypedTransactionParserError {
@@ -171,8 +187,8 @@ impl TryFrom<TypedTransactionArgs> for TransactionRequest {
     fn try_from(value: TypedTransactionArgs) -> Result<Self, Self::Error> {
         let TypedTransactionArgs {
             from,
-            address,
-            ens,
+            to: address,
+            ens_to,
             gas,
             gas_price,
             value,
@@ -183,7 +199,7 @@ impl TryFrom<TypedTransactionArgs> for TransactionRequest {
 
         let mut tx = TransactionRequest::new();
 
-        if ens.is_some() && address.is_some() {
+        if ens_to.is_some() && address.is_some() {
             return Err(Self::Error::ConflictingTransactionReceiver);
         }
 
@@ -195,7 +211,7 @@ impl TryFrom<TypedTransactionArgs> for TransactionRequest {
             tx = tx.to(address)
         }
 
-        if let Some(ens) = ens {
+        if let Some(ens) = ens_to {
             tx = tx.to(ens)
         }
 
@@ -229,9 +245,11 @@ impl TryFrom<TypedTransactionArgs> for TransactionRequest {
 
 #[derive(Args, Debug)]
 pub struct GetAccountArgs {
+    /// Ethereum address for the account
     #[arg(long, conflicts_with = "ens", required_unless_present = "ens")]
     address: Option<H160>,
 
+    /// Ens name for the account
     #[arg(long)]
     ens: Option<String>,
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,3 +3,4 @@ pub mod block;
 mod common;
 pub mod gas;
 pub mod transaction;
+pub mod utils;

--- a/src/cli/transaction.rs
+++ b/src/cli/transaction.rs
@@ -11,7 +11,7 @@ use crate::{
 
 use super::common::{
     parse_not_found, BlockIdParserError, GetBlockByIdArgs, NoArgs, TypedTransactionArgs,
-    TypedTransactionParserError, GET_BLOCK_BY_ID_ARG_GROUP_NAME,
+    TypedTransactionParserError, GET_BLOCK_BY_ID_ARG_GROUP_NAME, TX_ARGS_FIELD_NAMES,
 };
 use clap::{arg, command, Args, Parser, Subcommand};
 use ethers::types::{Bytes, Transaction, TransactionReceipt, H256};
@@ -59,7 +59,7 @@ pub struct GetTransactionArgs {
 pub struct SendTransactionArgs {
     // Raw tx args
     /// Rlp encoded transaction data
-    #[arg(long,conflicts_with_all(["from", "address", "ens","gas", "gas_price", "value", "data", "chain_id"]))]
+    #[arg(long,conflicts_with_all = TX_ARGS_FIELD_NAMES)]
     raw: Option<Bytes>,
 
     // Typed Tx args

--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -1,0 +1,133 @@
+use crate::{
+    cmd::utils::{self, SignTransactionData},
+    context::CommandExecutionContext,
+};
+use clap::{command, Args, Parser, Subcommand};
+use ethers::types::{Bytes, EIP1186ProofResponse, Signature, SyncingStatus, H160, H256, U256};
+use serde::Serialize;
+
+use super::common::{
+    GetAccountArgs, GetBlockByIdArgs, NoArgs, TypedTransactionArgs, TypedTransactionParserError,
+    TX_ARGS_FIELD_NAMES,
+};
+
+#[derive(Parser, Debug)]
+#[command()]
+pub struct UtilsCommand {
+    #[command(subcommand)]
+    command: UtilsSubCommand,
+}
+
+#[derive(Subcommand, Debug)]
+#[command()]
+pub enum UtilsSubCommand {
+    /// Gets the accounts known by the node
+    Accounts(NoArgs),
+
+    /// Gets the chain id from the node
+    ChainId(NoArgs),
+
+    /// Gets the EIP-1186 proof for the provided input
+    Proof(GetProofArgs),
+
+    /// Gets the ethereum protocol version
+    ProtocolVersion(NoArgs),
+
+    /// Signs the given transaction or data
+    Sign(SignArgs),
+
+    /// Gets the current sync status for the node
+    SyncStatus(NoArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct GetProofArgs {
+    #[clap(flatten)]
+    get_account_by_id: GetAccountArgs,
+
+    #[arg()]
+    storage_locations: Vec<H256>,
+
+    #[clap(flatten)]
+    get_block_by_id: GetBlockByIdArgs,
+}
+
+#[derive(Args, Debug)]
+pub struct SignArgs {
+    #[clap(flatten)]
+    get_account_by_id: GetAccountArgs,
+
+    /// Raw byte data to sign
+    #[clap(conflicts_with_all = TX_ARGS_FIELD_NAMES)]
+    raw: Option<Bytes>,
+
+    #[clap(flatten)]
+    typed_tx: TypedTransactionArgs,
+}
+
+impl TryFrom<TypedTransactionArgs> for SignTransactionData {
+    type Error = TypedTransactionParserError;
+
+    fn try_from(tx: TypedTransactionArgs) -> Result<Self, Self::Error> {
+        Ok(Self::Transaction(tx.try_into()?))
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum UtilsNamespaceResult {
+    Accounts(Vec<H160>),
+    ChainId(U256),
+    Proof(EIP1186ProofResponse),
+    ProtocolVersion(U256),
+    Sign(Signature),
+    SyncStatus(SyncingStatus),
+}
+
+pub fn parse(
+    context: &CommandExecutionContext,
+    sub_command: UtilsCommand,
+) -> Result<UtilsNamespaceResult, anyhow::Error> {
+    let node_provider = context.node_provider();
+
+    let res: UtilsNamespaceResult = match sub_command.command {
+        UtilsSubCommand::Accounts(_) => context
+            .execute(utils::get_accounts(node_provider))
+            .map(UtilsNamespaceResult::Accounts),
+        UtilsSubCommand::ChainId(_) => context
+            .execute(utils::get_chain_id(node_provider))
+            .map(UtilsNamespaceResult::ChainId),
+        UtilsSubCommand::Proof(GetProofArgs {
+            get_account_by_id,
+            storage_locations,
+            get_block_by_id,
+        }) => context
+            .execute(utils::get_proof(
+                node_provider,
+                get_account_by_id.try_into()?,
+                storage_locations,
+                get_block_by_id.try_into().ok(),
+            ))
+            .map(UtilsNamespaceResult::Proof),
+        UtilsSubCommand::ProtocolVersion(_) => context
+            .execute(utils::get_protocol_version(node_provider))
+            .map(UtilsNamespaceResult::ProtocolVersion),
+        UtilsSubCommand::Sign(SignArgs {
+            get_account_by_id,
+            raw: data,
+            typed_tx: tx,
+        }) => context
+            .execute(utils::sign(
+                node_provider,
+                get_account_by_id.try_into()?,
+                data.map(SignTransactionData::Raw)
+                    .map_or_else(|| tx.try_into(), Ok)?,
+            ))
+            .map(UtilsNamespaceResult::Sign),
+        UtilsSubCommand::SyncStatus(_) => context
+            .execute(utils::get_sync_status(node_provider))
+            .map(UtilsNamespaceResult::SyncStatus),
+    }?;
+
+    Ok(res)
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -3,3 +3,4 @@ pub mod block;
 pub mod gas;
 mod helpers;
 pub mod transaction;
+pub mod utils;

--- a/src/cmd/utils.rs
+++ b/src/cmd/utils.rs
@@ -285,6 +285,12 @@ mod tests {
             // Assert
             assert!(res.is_ok());
 
+            let tx_with_chain_id = tx.chain_id(anvil.chain_id());
+            let sig = res.unwrap();
+            assert!(sig
+                .verify(RecoveryMessage::Hash(tx_with_chain_id.sighash()), from)
+                .is_ok());
+
             Ok(())
         }
     }

--- a/src/cmd/utils.rs
+++ b/src/cmd/utils.rs
@@ -1,0 +1,131 @@
+use crate::context::NodeProvider;
+use anyhow::Result;
+use ethers::{
+    providers::Middleware,
+    types::{BlockId, EIP1186ProofResponse, NameOrAddress, H160, H256, U256},
+};
+
+// eth_accounts
+pub async fn get_accounts(node_provider: &NodeProvider) -> Result<Vec<H160>> {
+    let accounts = node_provider.get_accounts().await?;
+
+    Ok(accounts)
+}
+
+// eth_chainId
+pub async fn get_chain_id(node_provider: &NodeProvider) -> Result<U256> {
+    let chain_id = node_provider.get_chainid().await?;
+
+    Ok(chain_id)
+}
+
+// eth_getProof
+pub async fn get_proof(
+    node_provider: &NodeProvider,
+    address: NameOrAddress,
+    storage_locations: Vec<H256>,
+    block_id: Option<BlockId>,
+) -> Result<EIP1186ProofResponse> {
+    let account_proof = node_provider
+        .get_proof(address, storage_locations, block_id)
+        .await?;
+
+    Ok(account_proof)
+}
+
+#[cfg(test)]
+mod tests {
+
+    mod get_accounts {
+
+        use ethers::types::H160;
+
+        use crate::cmd::{helpers::test::setup_test, utils::get_accounts};
+
+        #[tokio::test]
+        async fn should_get_the_accounts_known_by_the_node() -> anyhow::Result<()> {
+            // Arrange
+            let (node_provider, _anvil) = setup_test().await?;
+
+            let expected_res: [H160; 10] = [
+                "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266".parse()?,
+                "0x70997970c51812dc3a010c7d01b50e0d17dc79c8".parse()?,
+                "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc".parse()?,
+                "0x90f79bf6eb2c4f870365e785982e1f101e93b906".parse()?,
+                "0x15d34aaf54267db7d7c367839aaf71a00a2c6a65".parse()?,
+                "0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc".parse()?,
+                "0x976ea74026e726554db657fa54763abd0c3a0aa9".parse()?,
+                "0x14dc79964da2c08b23698b3d3cc7ca32193d9955".parse()?,
+                "0x23618e81e3f5cdf7f54c3d65f7fbc0abf5b21e8f".parse()?,
+                "0xa0ee7a142d267c1f36714e4a8f75612f20a79720".parse()?,
+            ];
+
+            // Act
+            let res = get_accounts(&node_provider).await;
+
+            // Assert
+            assert!(res.is_ok());
+
+            let maybe_accounts = res.unwrap();
+            assert_eq!(maybe_accounts.len(), 10);
+            assert_eq!(maybe_accounts, expected_res);
+
+            Ok(())
+        }
+    }
+
+    mod get_chain_id {
+
+        use ethers::types::U256;
+
+        use crate::cmd::{helpers::test::setup_test, utils::get_chain_id};
+
+        #[tokio::test]
+        async fn should_get_the_chain_id() -> anyhow::Result<()> {
+            // Arrange
+            let (node_provider, _anvil) = setup_test().await?;
+
+            let expected_res: U256 = 31337.into();
+
+            // Act
+            let res = get_chain_id(&node_provider).await;
+
+            // Assert
+            assert!(res.is_ok());
+
+            let maybe_chain_id = res.unwrap();
+            assert_eq!(maybe_chain_id, expected_res);
+
+            Ok(())
+        }
+    }
+
+    mod get_proof {
+
+        use ethers::utils::parse_ether;
+
+        use crate::cmd::{helpers::test::setup_test, utils::get_proof};
+
+        #[tokio::test]
+        async fn should_get_the_account_merkle_proof() -> anyhow::Result<()> {
+            // Arrange
+            let (node_provider, _anvil) = setup_test().await?;
+
+            let account = *_anvil.addresses().get(0).unwrap();
+            let expected_account_balance = parse_ether(10000)?;
+
+            // Act
+            let res = get_proof(&node_provider, account.into(), [].into(), None).await;
+
+            // Assert
+            assert!(res.is_ok());
+
+            let maybe_account_proof = res.unwrap();
+            assert_eq!(maybe_account_proof.address, account);
+            assert_eq!(maybe_account_proof.balance, expected_account_balance);
+            assert_eq!(maybe_account_proof.nonce, 0.into());
+
+            Ok(())
+        }
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -89,6 +89,13 @@ impl NodeProvider {
 
         Ok(res)
     }
+
+    /// Returns the current ethereum protocol version.
+    pub async fn get_protocol_version(&self) -> anyhow::Result<U256> {
+        let res = self.inner().request("eth_protocolVersion", ()).await?;
+
+        Ok(res)
+    }
 }
 
 #[derive(Error, Debug)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -6,7 +6,7 @@ use ethers::{
     },
     providers::{Http, MiddlewareError, PendingTransaction, Provider, ProviderError},
     signers::{LocalWallet, Wallet},
-    types::{transaction::eip2718::TypedTransaction, BlockId, U256},
+    types::{transaction::eip2718::TypedTransaction, Address, BlockId, Signature, U256},
 };
 use std::future::Future;
 use thiserror::Error;
@@ -163,6 +163,23 @@ impl Middleware for NodeProvider {
                 .map_err(NodeProviderError::ProviderError),
             NodeProvider::ProviderWithSigner(signer_provider) => signer_provider
                 .send_transaction(tx, block)
+                .await
+                .map_err(NodeProviderError::ProviderWithSignerError),
+        }
+    }
+
+    async fn sign_transaction(
+        &self,
+        tx: &TypedTransaction,
+        from: Address,
+    ) -> Result<Signature, Self::Error> {
+        match self {
+            NodeProvider::Provider(provider) => provider
+                .sign_transaction(tx, from)
+                .await
+                .map_err(NodeProviderError::ProviderError),
+            NodeProvider::ProviderWithSigner(signer_provider) => signer_provider
+                .sign_transaction(tx, from)
                 .await
                 .map_err(NodeProviderError::ProviderWithSignerError),
         }

--- a/src/run.rs
+++ b/src/run.rs
@@ -9,6 +9,7 @@ use crate::{
         block::{self, BlockCommand, BlockNamespaceResult},
         gas::{self, GasCommand, GasNamespaceResult},
         transaction::{self, TransactionCommand, TransactionNamespaceResult},
+        utils::{self, UtilsCommand, UtilsNamespaceResult},
     },
     config::{get_config, ConfigOverrides},
     context::CommandExecutionContext,
@@ -69,8 +70,7 @@ enum Command {
     Gas(GasCommand),
 
     /// Collection of utils
-    #[command(subcommand)]
-    Utils(NoSubCommand),
+    Utils(UtilsCommand),
 }
 
 #[derive(Subcommand, Debug)]
@@ -84,6 +84,7 @@ pub enum CliResult {
     AccountNamespace(AccountNamespaceResult),
     TransactionNamespace(TransactionNamespaceResult),
     GasNamespace(GasNamespaceResult),
+    UtilsNamespace(UtilsNamespaceResult),
 }
 
 #[derive(Debug, Clone)]
@@ -147,7 +148,7 @@ pub fn run() -> Result<(), anyhow::Error> {
         }
         Command::Event(_) => todo!(),
         Command::Gas(cmd) => gas::parse(&execution_context, cmd).map(CliResult::GasNamespace),
-        Command::Utils(_) => todo!(),
+        Command::Utils(cmd) => utils::parse(&execution_context, cmd).map(CliResult::UtilsNamespace),
     }?;
 
     format_output(res, cli.out, cli.file)


### PR DESCRIPTION
### Changelog

- Renames the `ens` and `address` fields to `ens_to` and `to` in `TypedTransactionArgs` to avoid conflicts when the struct is used with `GetAccountArgs`
- Moves the `GetAccountsArgs` to the `cli/common` mod
- Implements the `utils` namespace
- Implements `get_protocol_version` on `NodeProvider`\
- Adds a custom implementation of `sign_transaction` on `NodeProvider`
- Tests the `utils` namespace